### PR TITLE
Replace `sys.exit` with `raise SystemExit`

### DIFF
--- a/maze.py
+++ b/maze.py
@@ -5,7 +5,6 @@ import curses
 from locale import setlocale, LC_ALL
 from random import choice, randint, shuffle
 from math import ceil
-from sys import exit
 from time import sleep
 from argparse import ArgumentParser
 
@@ -309,4 +308,4 @@ def main():
 
 
 if __name__ == '__main__':
-    exit(main())
+    raise SystemExit(main())


### PR DESCRIPTION
Just removed extra import statement (no difference in functionality)
[Stack Overflow question](https://stackoverflow.com/questions/35850362/importerror-no-module-named-curses-when-trying-to-import-blessings)
[Anthony's explain](https://www.youtube.com/watch?v=ZbeSPc5wL0g)