### PR TITLE
Fix `ModuleNotFoundError` on Windows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,3 +24,9 @@ terminal. If at any point you wish to uninstall just run the following command:
 ::
 
     % pip3 uninstall maze.py
+
+If you on Windows, install additional dependencies:
+
+::
+
+    pip install -r win-requirements.txt

--- a/win-requirements.txt
+++ b/win-requirements.txt
@@ -1,0 +1,1 @@
+windows-curses>=2.3


### PR DESCRIPTION
To run this script on Windows, it requires to install `windows-curses`
package